### PR TITLE
fixed pagination and like count

### DIFF
--- a/src/pages/posts/Posts.tsx
+++ b/src/pages/posts/Posts.tsx
@@ -10,6 +10,9 @@ import { QueryStateWrapper } from '../../shared/QueryStateWrapper';
 import { TheIcon } from '../../shared/TheIcon';
 import {FaPlus} from 'react-icons/fa'
 import { Link } from 'react-router-dom';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { pb_url } from './../../utils/env';
+import dayjs  from 'dayjs';
 interface PostsProps {
   user: Record | Admin | null | undefined
 }
@@ -21,45 +24,83 @@ export interface RecordItem extends Record {
 
 export const Posts: React.FC<PostsProps> = ({user}) => {
   const { ref, inView } = useInView()
-
-  const postsQuery = usePaginatedCollection<PostType>(
-    ['posts'],
-     {
-      perpage:5,
-      expand:'emp',
-     },
+  interface Deps {
+    pageParam: {
+      created: string, id: string
+    }
+  }
+  // console.log("user === ",user)
+  const fetchPosts = async (deps: Partial<Deps>) => {
+    // console.log("page params dependaces === ", deps, deps.pageParam?.id)
+    const currentdate = dayjs(new Date()).format('[YYYYescape] YYYY-MM-DDTHH:mm:ssZ[Z]') 
+    let headersList = {
+      "Accept": "*/*",
+    }
+    const response = await fetch(
+      `${pb_url}/post_reactions/?id=${deps.pageParam?.id??""}&user=${user?.id??""}&created=${deps.pageParam?.created??currentdate}`, {
+      method: "GET",
+      headers: headersList
+    });
+    return await response.json();
+  }
+  const customPostsQuery = useInfiniteQuery<CustomPostType[], unknown, CustomPostType[], string[]>(
+    ['posts-list'],
+  fetchPosts,
     {
-   
-     getNextPageParam: (lastPage, allPages) =>{
-        if(lastPage.totalPages > lastPage.page){
-            return lastPage.page + 1
+      getNextPageParam: (lastPage, allPages) => {
+        // console.log("last page ==== ",lastPage,allPages)
+        if (lastPage && lastPage[lastPage.length - 1]) {
+        return { 
+          created: lastPage[lastPage?.length - 1]?.created_at, 
+          id: lastPage[lastPage?.length - 1]?.post_id
+}
         }
-          return 
-        }
-     }
+        return
+      }
+    })
   
-  )
-const data =postsQuery.data
-// console.log("data ====>> ",data)
+  // console.log("fetched posts querys=== ",customPostsQuery.data)
+  
+  // const postsQuery = usePaginatedCollection<PostType>(
+  //   ['posts'],
+  //    {
+  //     perpage:5,
+  //     expand:'emp',
+  //    },
+  //   {
+  //     getNextPageParam: (lastPage, allPages) =>{
+  //       if(lastPage.totalPages > lastPage.page){
+  //           return lastPage.page + 1
+  //       }
+  //         return 
+  //     }
+  //    }
+  
+  // )
+  const data = customPostsQuery.data
+// const data =postsQuery.data
+// console.log("data ====>> ",data?.pages)
   React.useEffect(() => {
     if (inView) {
-      postsQuery.fetchNextPage()
+      customPostsQuery.fetchNextPage()
     }
   }, [inView])
 
 return (
   <QueryStateWrapper
-  error={postsQuery.error}
-  isError={postsQuery.isError}
-  isLoading={postsQuery.isLoading}
+  error={customPostsQuery.error}
+  isError={customPostsQuery.isError}
+  isLoading={customPostsQuery.isLoading}
   data={data?.pages}
   >
  <div className='w-full min-h-full flex flex-col gap-2 items-center justify-center'>
 <div className='w-[95%] h-full flex flex-col items-center justify-center gap-2'>
       {data?.pages.map((page) => {
-        return page.items.map((item) => {
-          return <PostsCard item={item} key={item.id} user={user}/>
+        // console.log("page=== ",page)
+        return page.map((item) => {
+          return <PostsCard item={item} key={item.post_id} user={user}/>
         })
+        return <div>hey</div>
       })
       }
 </div>
@@ -74,12 +115,12 @@ return (
     <div>
        <button
         ref={ref}
-        onClick={() => postsQuery.fetchNextPage()}
-        disabled={!postsQuery.hasNextPage || postsQuery.isFetchingNextPage}
+          onClick={() => customPostsQuery.fetchNextPage()}
+        disabled={!customPostsQuery.hasNextPage || customPostsQuery.isFetchingNextPage}
       >
-        {postsQuery.isFetchingNextPage? 'Loading more...'
-          : postsQuery.hasNextPage ? 'Load More'
-            : !postsQuery.isLoading? 'Nothing more to load':null}
+        {customPostsQuery.isFetchingNextPage? 'Loading more...'
+            : customPostsQuery.hasNextPage ? 'Load More'
+              : !customPostsQuery.isLoading? 'Nothing more to load':null}
       </button>
     </div>
 
@@ -90,5 +131,16 @@ return (
 
 
 
-
+export interface CustomPostType {
+  creator_id: string
+  creator_name: string
+  creator_image: string
+  post_id: string
+  post_body: string
+  post_media: string
+  created_at: string
+  likes: number
+  mylike: string
+  reaction_id:string
+}
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -6,6 +6,7 @@ const local_pb = "http://127.0.0.1:8090";
 const web1_url = "https://emps.tigawanna.tech"
 const vercel_url ="https://mech-up-vite.vercel.app";
 export const pb_url=web1_url
+// export const pb_url=local_pb
 export const main_url =vercel_url
 // export const main_url = local_url
 export const redirect_url=main_url+"/redirect"


### PR DESCRIPTION
## extended pocketbase to add a custom route 

```sql
		select 
			p.emp creator_id,
			e.username creator_name,
            e.avatar creator_image,
            
			p.id    post_id,
			p.body post_body,
			p.media post_media,
			p.created created_at,
			
			(count(CASE WHEN r.liked = 'yes' THEN 1 END)) likes ,
			(CASE WHEN  r.emp = {:user} AND r.liked = 'yes'  THEN 'yes' ELSE 'no' END) mylike,
			(CASE WHEN r.id is not NULL THEN  r.id ELSE "" END ) reaction_id

			from posts p
				LEFT JOIN reactions r on r.post = p.id
			LEFT JOIN emps e on e.id = p.emp 
                
			WHERE (p.created < {:created} 
				OR (p.created = {:created} AND p.id < {:id})
					
			)
       
		       GROUP BY p.id
			    	ORDER BY p.created DESC, p.id DESC
			  LIMIT 5
```
to do joins and get total like count, fields that I've like  plus pagination